### PR TITLE
[patch] DHL express tracking response parsing issue

### DIFF
--- a/extensions/dhl_express/pyproject.toml
+++ b/extensions/dhl_express/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "purplship.dhl_express"
-version = "2021.4.1"
+version = "2021.4.2"
 homepage="https://sdk.purplship.com"
 repository="https://github.com/Purplship/purplship"
 description = "Purplship - DHL Express Shipping Extension"

--- a/poetry.lock
+++ b/poetry.lock
@@ -570,7 +570,7 @@ python-versions = ">=3.6"
 
 [[package]]
 name = "purplship"
-version = "2021.3.1"
+version = "2021.4.1"
 description = "Multi-carrier shipping API integration with python"
 category = "dev"
 optional = false
@@ -677,7 +677,7 @@ url = "extensions/canpar"
 
 [[package]]
 name = "purplship.dhl-express"
-version = "2021.3.1"
+version = "2021.4.2"
 description = "Purplship - DHL Express Shipping Extension"
 category = "dev"
 optional = false
@@ -927,7 +927,7 @@ six = ">=1.15.0,<2.0.0"
 
 [[package]]
 name = "pygments"
-version = "2.8.1"
+version = "2.9.0"
 description = "Pygments is a syntax highlighting package written in Python."
 category = "dev"
 optional = false
@@ -948,7 +948,7 @@ Markdown = ">=3.2"
 name = "pyyaml"
 version = "5.4.1"
 description = "YAML parser and emitter for Python"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
 
@@ -962,7 +962,7 @@ python-versions = "*"
 
 [[package]]
 name = "six"
-version = "1.15.0"
+version = "1.16.0"
 description = "Python 2 and 3 compatibility utilities"
 category = "dev"
 optional = false
@@ -1027,7 +1027,7 @@ python-versions = "*"
 
 [[package]]
 name = "typing-extensions"
-version = "3.7.4.3"
+version = "3.10.0.0"
 description = "Backported and Experimental Type Hints for Python 3.5+"
 category = "dev"
 optional = false
@@ -1056,7 +1056,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pyt
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "77b37569c62867ebc292db7946e2441f6a7bf939c7896f30dafc8d26fe4137e5"
+content-hash = "d7e6d8972a840ccb35547a9883434fede1b99588817c8b2039b63a96ce307e1b"
 
 [metadata.files]
 appdirs = [
@@ -1419,8 +1419,8 @@ py-soap = [
     {file = "py_soap-2020.3.2-py3-none-any.whl", hash = "sha256:61e2ec956d349bdd9d4c6248a2ae3c4cc4b0a2a5cf6b439b6de480a3bc2766a1"},
 ]
 pygments = [
-    {file = "Pygments-2.8.1-py3-none-any.whl", hash = "sha256:534ef71d539ae97d4c3a4cf7d6f110f214b0e687e92f9cb9d2a3b0d3101289c8"},
-    {file = "Pygments-2.8.1.tar.gz", hash = "sha256:2656e1a6edcdabf4275f9a3640db59fd5de107d88e8663c5d4e9a0fa62f77f94"},
+    {file = "Pygments-2.9.0-py3-none-any.whl", hash = "sha256:d66e804411278594d764fc69ec36ec13d9ae9147193a1740cd34d272ca383b8e"},
+    {file = "Pygments-2.9.0.tar.gz", hash = "sha256:a18f47b506a429f6f4b9df81bb02beab9ca21d0a5fee38ed15aef65f0545519f"},
 ]
 pymdown-extensions = [
     {file = "pymdown-extensions-8.1.1.tar.gz", hash = "sha256:632371fa3bf1b21a0e3f4063010da59b41db049f261f4c0b0872069a9b6d1735"},
@@ -1493,8 +1493,8 @@ regex = [
     {file = "regex-2021.4.4.tar.gz", hash = "sha256:52ba3d3f9b942c49d7e4bc105bb28551c44065f139a65062ab7912bef10c9afb"},
 ]
 six = [
-    {file = "six-1.15.0-py2.py3-none-any.whl", hash = "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"},
-    {file = "six-1.15.0.tar.gz", hash = "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259"},
+    {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
+    {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
 ]
 smmap = [
     {file = "smmap-4.0.0-py2.py3-none-any.whl", hash = "sha256:a9a7479e4c572e2e775c404dcd3080c8dc49f39918c2cf74913d30c4c478e3c2"},
@@ -1588,9 +1588,9 @@ typed-ast = [
     {file = "typed_ast-1.4.3.tar.gz", hash = "sha256:fb1bbeac803adea29cedd70781399c99138358c26d05fcbd23c13016b7f5ec65"},
 ]
 typing-extensions = [
-    {file = "typing_extensions-3.7.4.3-py2-none-any.whl", hash = "sha256:dafc7639cde7f1b6e1acc0f457842a83e722ccca8eef5270af2d74792619a89f"},
-    {file = "typing_extensions-3.7.4.3-py3-none-any.whl", hash = "sha256:7cb407020f00f7bfc3cb3e7881628838e69d8f3fcab2f64742a5e76b2f841918"},
-    {file = "typing_extensions-3.7.4.3.tar.gz", hash = "sha256:99d4073b617d30288f569d3f13d2bd7548c3a7e4c8de87db09a9d29bb3a4a60c"},
+    {file = "typing_extensions-3.10.0.0-py2-none-any.whl", hash = "sha256:0ac0f89795dd19de6b97debb0c6af1c70987fd80a2d62d1958f7e56fcc31b497"},
+    {file = "typing_extensions-3.10.0.0-py3-none-any.whl", hash = "sha256:779383f6086d90c99ae41cf0ff39aac8a7937a9283ce0a414e5dd782f4c94a84"},
+    {file = "typing_extensions-3.10.0.0.tar.gz", hash = "sha256:50b6f157849174217d0656f99dc82fe932884fb250826c18350e159ec6cdf342"},
 ]
 xmltodict = [
     {file = "xmltodict-0.12.0-py2.py3-none-any.whl", hash = "sha256:8bbcb45cc982f48b2ca8fe7e7827c5d792f217ecf1792626f808bf41c3b86051"},

--- a/purplship/purplship/core/utils/xml.py
+++ b/purplship/purplship/core/utils/xml.py
@@ -35,7 +35,7 @@ class XMLPARSER:
         return instance
 
     @staticmethod
-    def find(tag: str, in_element: Element, element_type: Type[Union[T, Element]] = Element, first: bool = None):
+    def find(tag: str, in_element: Element, element_type: Type[Union[T, Element]] = None, first: bool = None):
         children = [
             (child if element_type is None else XMLPARSER.build(element_type, child))
             for child in in_element.xpath(".//*[local-name() = $name]", name=tag)

--- a/purplship/pyproject.toml
+++ b/purplship/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "purplship"
-version = "2021.4"
+version = "2021.4.1"
 homepage="https://sdk.purplship.com"
 repository="https://github.com/Purplship/purplship"
 description = "Multi-carrier shipping API integration with python"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ license = "LGPLv3"
 
 [tool.poetry.dependencies]
 python = "^3.7"
+PyYAML = "^5.4.1"
 
 [tool.poetry.dev-dependencies]
 bandit = "^1.7.0"

--- a/tests/dhl_express/tracking.py
+++ b/tests/dhl_express/tracking.py
@@ -46,6 +46,17 @@ class TestDHLTracking(unittest.TestCase):
                 DP.to_dict(parsed_response), DP.to_dict(ParsedTrackingResponse)
             )
 
+    def test_parse_in_transit_tracking_response(self):
+        with patch("purplship.mappers.dhl_express.proxy.http") as mock:
+            mock.return_value = IntransitTrackingResponseXML
+            parsed_response = (
+                Tracking.fetch(self.TrackingRequest).from_(gateway).parse()
+            )
+
+            self.assertEqual(
+                DP.to_dict(parsed_response), DP.to_dict(ParsedInTransitTrackingResponse)
+            )
+
     def test_tracking_single_not_found_parsing(self):
         with patch("purplship.mappers.dhl_express.proxy.http") as mock:
             mock.return_value = TrackingSingleNotFound
@@ -243,6 +254,27 @@ ParsedTrackingResponse = [
             ],
             "tracking_number": "1815115363",
         },
+    ],
+    [],
+]
+
+ParsedInTransitTrackingResponse = [
+    [
+        {
+            "carrier_id": "carrier_id",
+            "carrier_name": "dhl_express",
+            "delivered": False,
+            "events": [
+                {
+                    "code": "PU",
+                    "date": "2021-05-05",
+                    "description": "Shipment picked up",
+                    "location": "KINGSTON-JAM",
+                    "time": "09:42",
+                }
+            ],
+            "tracking_number": "9053283201",
+        }
     ],
     [],
 ]
@@ -640,4 +672,72 @@ TrackingResponseXML = """<?xml version="1.0" encoding="UTF-8"?>
         </ShipmentInfo>
     </AWBInfo>
 </req:TrackingResponse>
+"""
+
+IntransitTrackingResponseXML = """<?xml version="1.0" encoding="UTF-8"?>
+<req:TrackingResponse xmlns:req="http://www.dhl.com" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.dhl.com TrackingResponse.xsd">
+    <Response>
+        <ServiceHeader>
+            <MessageTime>2021-05-05T16:11:31+00:00</MessageTime>
+            <MessageReference>1234567890123456789012345678901</MessageReference>
+            <SiteID>v62_0jd1ITXeJI</SiteID>
+        </ServiceHeader>
+    </Response>
+    <AWBInfo>
+        <AWBNumber>9053283201</AWBNumber>
+        <Status>
+            <ActionStatus>success</ActionStatus>
+        </Status>
+        <ShipmentInfo>
+            <OriginServiceArea>
+                <ServiceAreaCode>KIN</ServiceAreaCode>
+                <Description>KINGSTON-JAM</Description>
+            </OriginServiceArea>
+            <DestinationServiceArea>
+                <ServiceAreaCode>LGA</ServiceAreaCode>
+                <Description>SPRINGFIELD GARDENS,NY-USA</Description>
+            </DestinationServiceArea>
+            <ShipperName>CARIBSHOPPER JA - KEX</ShipperName>
+            <ShipperAccountNumber>968490657</ShipperAccountNumber>
+            <ConsigneeName>TAMARA SPENCE</ConsigneeName>
+            <ShipmentDate>2021-05-04T16:06:40</ShipmentDate>
+            <Pieces>1</Pieces>
+            <Weight>0.09</Weight>
+            <WeightUnit>K</WeightUnit>
+            <EstDlvyDate>2021-05-07 23:59:00 GMT-04:00</EstDlvyDate>
+            <EstDlvyDateUTC>2021-05-08 03:59:00</EstDlvyDateUTC>
+            <GlobalProductCode>P</GlobalProductCode>
+            <ShipmentDesc>ariSulfur Facial and Body Bar</ShipmentDesc>
+            <DlvyNotificationFlag>Y</DlvyNotificationFlag>
+            <Shipper>
+                <City>Kingston 10</City>
+                <CountryCode>JM</CountryCode>
+            </Shipper>
+            <Consignee>
+                <City>BROOKLYN</City>
+                <DivisionCode>NY</DivisionCode>
+                <PostalCode>11233</PostalCode>
+                <CountryCode>US</CountryCode>
+            </Consignee>
+            <ShipperReference>
+                <ReferenceID>28707</ReferenceID>
+            </ShipperReference>
+            <ShipmentEvent>
+                <Date>2021-05-05</Date>
+                <Time>09:42:00</Time>
+                <ServiceEvent>
+                    <EventCode>PU</EventCode>
+                    <Description>Shipment picked up</Description>
+                </ServiceEvent>
+                <Signatory/>
+                <ServiceArea>
+                    <ServiceAreaCode>KIN</ServiceAreaCode>
+                    <Description>KINGSTON-JAM</Description>
+                </ServiceArea>
+            </ShipmentEvent>
+        </ShipmentInfo>
+    </AWBInfo>
+    <LanguageCode>en</LanguageCode>
+</req:TrackingResponse>
+<!-- ServiceInvocationId:20210505161131_108e_5805c60e-a6f4-49c8-8b1b-05af96e35c97 -->
 """


### PR DESCRIPTION
DHL returns a different date `EstDlvyDate` than the format defined in the XML-pi toolkit.
Fix tracking response parsing by accessing directly the expected XML nodes