### PR TITLE
[patch] Improve Service reference parsing

### DIFF
--- a/extensions/canadapost/purplship/providers/canadapost/rate.py
+++ b/extensions/canadapost/purplship/providers/canadapost/rate.py
@@ -26,36 +26,33 @@ from purplship.providers.canadapost.units import OptionCode, ServiceType, Packag
 def parse_rate_response(
         response: Element, settings: Settings
 ) -> Tuple[List[RateDetails], List[Message]]:
-    price_quotes = response.xpath(".//*[local-name() = $name]", name="price-quote")
+    price_quotes = XP.find("price-quote", response)
     quotes: List[RateDetails] = [
         _extract_quote(price_quote_node, settings) for price_quote_node in price_quotes
     ]
     return quotes, parse_error_response(response, settings)
 
 
-def _extract_quote(price_quote_node: Element, settings: Settings) -> RateDetails:
-    price_quote = XP.build(price_quoteType, price_quote_node)
-    adjustments = (
-        price_quote.price_details.adjustments.adjustment
-        if price_quote.price_details.adjustments is not None
-        else []
-    )
+def _extract_quote(node: Element, settings: Settings) -> RateDetails:
+    quote = XP.build(price_quoteType, node)
+    service = ServiceType.map(quote.service_code)
+    adjustments = getattr(quote.price_details.adjustments, 'adjustment', [])
     discount = sum(NF.decimal(d.adjustment_cost or 0) for d in adjustments)
-    transit_days = price_quote.service_standard.expected_transit_time
+    transit_days = quote.service_standard.expected_transit_time
 
     return RateDetails(
         carrier_name=settings.carrier_name,
         carrier_id=settings.carrier_id,
         currency=Currency.CAD.name,
         transit_days=transit_days,
-        service=ServiceType(price_quote.service_code).name,
-        base_charge=NF.decimal(price_quote.price_details.base or 0),
-        total_charge=NF.decimal(price_quote.price_details.due or 0),
+        service=service.name_or_key,
+        base_charge=NF.decimal(quote.price_details.base or 0),
+        total_charge=NF.decimal(quote.price_details.due or 0),
         discount=NF.decimal(discount),
         duties_and_taxes=NF.decimal(
-            float(price_quote.price_details.taxes.gst.valueOf_ or 0)
-            + float(price_quote.price_details.taxes.pst.valueOf_ or 0)
-            + float(price_quote.price_details.taxes.hst.valueOf_ or 0)
+            float(quote.price_details.taxes.gst.valueOf_ or 0)
+            + float(quote.price_details.taxes.pst.valueOf_ or 0)
+            + float(quote.price_details.taxes.hst.valueOf_ or 0)
         ),
         extra_charges=[
             ChargeDetails(
@@ -65,6 +62,9 @@ def _extract_quote(price_quote_node: Element, settings: Settings) -> RateDetails
             )
             for a in adjustments
         ],
+        meta=dict(
+            service_name=(service.name or quote.service_name)
+        )
     )
 
 
@@ -152,10 +152,3 @@ def _request_serializer(request: mailing_scenario) -> str:
     return XP.export(
         request, namespacedef_='xmlns="http://www.canadapost.ca/ws/ship/rate-v4"'
     )
-
-
-def _amount(value):
-    if isinstance(value, (bool)):
-        return None
-
-    return float(value)

--- a/extensions/canadapost/purplship/providers/canadapost/shipment/contract.py
+++ b/extensions/canadapost/purplship/providers/canadapost/shipment/contract.py
@@ -75,17 +75,14 @@ def shipment_request(
     payload: ShipmentRequest, settings: Settings
 ) -> Serializable[ShipmentType]:
     package = Packages(payload.parcels, PackagePresets, required=['weight']).single
-    service = ServiceType[payload.service].value
+    service = ServiceType.map(payload.service).value_or_key
     options = Options(payload.options, OptionCode)
 
     is_intl = (
         payload.recipient.country_code is not None and
         payload.recipient.country_code != 'CA'
     )
-    payment_type = (
-        PaymentType[payload.payment.paid_by].value
-        if payload.payment is not None else None
-    )
+    payment_type = PaymentType.map(getattr(payload.payment, 'paid_by', None)).value
     all_options = (
         [*options, (OptionCode.canadapost_return_to_sender.name, OptionCode.canadapost_return_to_sender.value.apply(True))]
         if is_intl and not any(key in options for key in INTERNATIONAL_NON_DELIVERY_OPTION) else [*options]

--- a/extensions/canadapost/purplship/providers/canadapost/shipment/non_contract.py
+++ b/extensions/canadapost/purplship/providers/canadapost/shipment/non_contract.py
@@ -67,7 +67,7 @@ def _extract_shipment(response: Element, settings: Settings) -> ShipmentDetails:
 
 def shipment_request(payload: ShipmentRequest, _) -> Serializable[NonContractShipmentType]:
     package = Packages(payload.parcels, PackagePresets, required=["weight"]).single
-    service = ServiceType[payload.service].value
+    service = ServiceType.map(payload.service).value_or_key
     options = Options(payload.options, OptionCode)
 
     is_intl = (

--- a/extensions/canadapost/purplship/providers/canadapost/units.py
+++ b/extensions/canadapost/purplship/providers/canadapost/units.py
@@ -91,6 +91,7 @@ class ServiceType(Enum):
     canadapost_regular_parcel = "DOM.RP"
     canadapost_expedited_parcel = "DOM.EP"
     canadapost_xpresspost = "DOM.XP"
+    canadapost_xpresspost_certified = "DOM.XP.CERT"
     canadapost_priority = "DOM.PC"
     canadapost_library_books = "DOM.LIB"
     canadapost_expedited_parcel_usa = "USA.EP"

--- a/extensions/canadapost/pyproject.toml
+++ b/extensions/canadapost/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "purplship.canadapost"
-version = "2021.6"
+version = "2021.6.1"
 homepage="https://sdk.purplship.com"
 repository="https://github.com/Purplship/purplship"
 description = "Purplship - Canada Post Shipping Extension"

--- a/purplship/purplship/core/utils/enum.py
+++ b/purplship/purplship/core/utils/enum.py
@@ -1,10 +1,9 @@
 import attr
-from typing import Optional, Type, Any, Callable
+from typing import Optional, Type, Any, Callable, Union, cast
 from enum import Enum as BaseEnum, Flag as BaseFlag, EnumMeta
 
 
 class MetaEnum(EnumMeta):
-
     def __contains__(cls, item):
         if item is None:
             return False
@@ -13,6 +12,14 @@ class MetaEnum(EnumMeta):
 
         return super().__contains__(item)
 
+    def map(cls, key: Any):
+        if key in cls:
+            return EnumWrapper(key, cls[key])
+        elif key in cast(BaseEnum, cls)._value2member_map_:
+            return EnumWrapper(key, cls(key))
+
+        return EnumWrapper(key)
+
 
 class Enum(BaseEnum, metaclass=MetaEnum):
     pass
@@ -20,6 +27,32 @@ class Enum(BaseEnum, metaclass=MetaEnum):
 
 class Flag(BaseFlag, metaclass=MetaEnum):
     pass
+
+
+@attr.s(auto_attribs=True)
+class EnumWrapper:
+    key: Any
+    enum: Optional[Enum] = None
+
+    @property
+    def name(self):
+        return getattr(self.enum, 'name', None)
+
+    @property
+    def value(self):
+        return getattr(self.enum, 'value', None)
+
+    @property
+    def name_or_key(self):
+        return getattr(self.enum, 'name', self.key)
+
+    @property
+    def value_or_key(self):
+        return getattr(self.enum, 'value', self.key)
+
+    @property
+    def object(self):
+        self.enum
 
 
 @attr.s(auto_attribs=True)

--- a/purplship/pyproject.toml
+++ b/purplship/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "purplship"
-version = "2021.6"
+version = "2021.6.1"
 homepage="https://sdk.purplship.com"
 repository="https://github.com/Purplship/purplship"
 description = "Multi-carrier shipping API integration with python"

--- a/tests/canadapost/rate.py
+++ b/tests/canadapost/rate.py
@@ -45,13 +45,17 @@ class TestCanadaPostRating(unittest.TestCase):
             mock.return_value = RateResponseXml
             parsed_response = Rating.fetch(self.RateRequest).from_(gateway).parse()
 
-            self.assertEqual(DP.to_dict(parsed_response), DP.to_dict(ParsedQuoteResponse))
+            self.assertEqual(
+                DP.to_dict(parsed_response), DP.to_dict(ParsedQuoteResponse)
+            )
 
     def test_parse_rate_parsing_error(self):
         with patch("purplship.mappers.canadapost.proxy.http") as mock:
             mock.return_value = QuoteParsingError
             parsed_response = Rating.fetch(self.RateRequest).from_(gateway).parse()
-            self.assertEqual(DP.to_dict(parsed_response), DP.to_dict(ParsedQuoteParsingError))
+            self.assertEqual(
+                DP.to_dict(parsed_response), DP.to_dict(ParsedQuoteParsingError)
+            )
 
     def test_parse_rate_missing_args_error(self):
         with patch("purplship.mappers.canadapost.proxy.http") as mock:
@@ -82,8 +86,8 @@ RatePayload = {
     "options": {
         "signature_confirmation": True,
         "shipment_date": "2020-12-18",
-        "insurance": 1000
-    }
+        "insurance": 1000,
+    },
 }
 
 RateWithPresetPayload = {
@@ -154,63 +158,67 @@ ParsedQuoteResponse = [
     [
         {
             "base_charge": 9.59,
-            "carrier_name": "canadapost",
             "carrier_id": "canadapost",
+            "carrier_name": "canadapost",
             "currency": "CAD",
             "discount": 0.62,
             "duties_and_taxes": 0.0,
-            "transit_days": 2,
             "extra_charges": [
                 {"amount": -0.29, "currency": "CAD", "name": "Automation discount"},
                 {"amount": 0.91, "currency": "CAD", "name": "Fuel surcharge"},
             ],
+            "meta": {"service_name": "canadapost_expedited_parcel"},
             "service": "canadapost_expedited_parcel",
             "total_charge": 10.21,
+            "transit_days": 2,
         },
         {
             "base_charge": 22.64,
-            "carrier_name": "canadapost",
             "carrier_id": "canadapost",
+            "carrier_name": "canadapost",
             "currency": "CAD",
             "discount": 2.56,
             "duties_and_taxes": 0.0,
-            "transit_days": 1,
             "extra_charges": [
                 {"amount": -0.68, "currency": "CAD", "name": "Automation discount"},
                 {"amount": 3.24, "currency": "CAD", "name": "Fuel surcharge"},
             ],
+            "meta": {"service_name": "canadapost_priority"},
             "service": "canadapost_priority",
             "total_charge": 25.2,
+            "transit_days": 1,
         },
         {
             "base_charge": 9.59,
-            "carrier_name": "canadapost",
             "carrier_id": "canadapost",
+            "carrier_name": "canadapost",
             "currency": "CAD",
             "discount": 0.62,
             "duties_and_taxes": 0.0,
-            "transit_days": 4,
             "extra_charges": [
                 {"amount": -0.29, "currency": "CAD", "name": "Automation discount"},
                 {"amount": 0.91, "currency": "CAD", "name": "Fuel surcharge"},
             ],
+            "meta": {"service_name": "canadapost_regular_parcel"},
             "service": "canadapost_regular_parcel",
             "total_charge": 10.21,
+            "transit_days": 4,
         },
         {
             "base_charge": 12.26,
-            "carrier_name": "canadapost",
             "carrier_id": "canadapost",
+            "carrier_name": "canadapost",
             "currency": "CAD",
             "discount": 1.38,
             "duties_and_taxes": 0.0,
-            "transit_days": 2,
             "extra_charges": [
                 {"amount": -0.37, "currency": "CAD", "name": "Automation discount"},
                 {"amount": 1.75, "currency": "CAD", "name": "Fuel surcharge"},
             ],
+            "meta": {"service_name": "canadapost_xpresspost"},
             "service": "canadapost_xpresspost",
             "total_charge": 13.64,
+            "transit_days": 2,
         },
     ],
     [],


### PR DESCRIPTION
- implement EnumWrapper for simple enum data access
- use `.map` enum helper to simplify Canada post service parsing and allow fallback when unknown