### PR TITLE
[patch] DHL Express dimension rounded to 0 error

### DIFF
--- a/extensions/dhl_express/purplship/providers/dhl_express/rate.py
+++ b/extensions/dhl_express/purplship/providers/dhl_express/rate.py
@@ -18,7 +18,7 @@ from dhl_express_lib.dct_response_global_2_0 import QtdShpType as ResponseQtdShp
 
 from purplship.core.errors import DestinationNotServicedError, OriginNotServicedError
 from purplship.core.utils import Serializable, Element, NF, XP, DF
-from purplship.core.units import Packages, Options, Package, WeightUnit, DimensionUnit, Services, CountryCurrency
+from purplship.core.units import Packages, Options, Package, Services, CountryCurrency
 from purplship.core.models import RateDetails, Message, ChargeDetails, RateRequest
 from purplship.providers.dhl_express.units import (
     ProductCode,
@@ -27,6 +27,7 @@ from purplship.providers.dhl_express.units import (
     SpecialServiceCode,
     NetworkType,
     COUNTRY_PREFERED_UNITS,
+    MeasurementOptions,
 )
 from purplship.providers.dhl_express.utils import Settings
 from purplship.providers.dhl_express.error import parse_error_response
@@ -154,9 +155,9 @@ def rate_request(payload: RateRequest, settings: Settings) -> Serializable[DCTRe
                             PackageTypeCode=DCTPackageType[
                                 package.packaging_type or "your_packaging"
                                 ].value,
-                            Depth=package.length[dim_unit.name],
-                            Width=package.width[dim_unit.name],
-                            Height=package.height[dim_unit.name],
+                            Depth=package.length.map(MeasurementOptions)[dim_unit.name],
+                            Width=package.width.map(MeasurementOptions)[dim_unit.name],
+                            Height=package.height.map(MeasurementOptions)[dim_unit.name],
                             Weight=package.weight[weight_unit.name],
                         )
                         for index, package in enumerate(

--- a/extensions/dhl_express/purplship/providers/dhl_express/shipment.py
+++ b/extensions/dhl_express/purplship/providers/dhl_express/shipment.py
@@ -39,13 +39,13 @@ from purplship.providers.dhl_express.units import (
     PaymentType,
     CountryRegion,
     SpecialServiceCode,
-    DeliveryType,
     PackagePresets,
     LabelType,
     ExportReasonCode,
     WeightUnit as DHLWeightUnit,
     DimensionUnit,
     COUNTRY_PREFERED_UNITS,
+    MeasurementOptions,
 )
 from purplship.providers.dhl_express.utils import Settings
 from purplship.providers.dhl_express.error import parse_error_response
@@ -261,9 +261,9 @@ def shipment_request(payload: ShipmentRequest, settings: Settings) -> Serializab
                         PackageType=(
                             package_type or PackageType[package.packaging_type or "your_packaging"].value
                         ),
-                        Depth=package.length[dim_unit.name],
-                        Width=package.width[dim_unit.name],
-                        Height=package.height[dim_unit.name],
+                        Depth=package.length.map(MeasurementOptions)[dim_unit.name],
+                        Width=package.width.map(MeasurementOptions)[dim_unit.name],
+                        Height=package.height.map(MeasurementOptions)[dim_unit.name],
                         Weight=package.weight[weight_unit.name],
                         PieceContents=(package.parcel.content or package.parcel.description),
                         PieceReference=(

--- a/extensions/dhl_express/purplship/providers/dhl_express/units.py
+++ b/extensions/dhl_express/purplship/providers/dhl_express/units.py
@@ -65,6 +65,11 @@ class PackagePresets(Flag):
     )
 
 
+class MeasurementOptions(Enum):
+    min_in = 1
+    min_cm = 1
+
+
 class LabelType(Flag):
     PDF_6x4 = ('PDF', '6X4_PDF')
     PDF_8x4 = ('PDF', '8X4_PDF')

--- a/extensions/dhl_express/purplship/providers/dhl_express/units.py
+++ b/extensions/dhl_express/purplship/providers/dhl_express/units.py
@@ -67,7 +67,7 @@ class PackagePresets(Flag):
 
 class MeasurementOptions(Enum):
     min_in = 1
-    min_cm = 1
+    min_cm = 1.1  # TODO:: refactor MeasurementOptions to use dict instead of enum
 
 
 class LabelType(Flag):

--- a/extensions/dhl_express/pyproject.toml
+++ b/extensions/dhl_express/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "purplship.dhl_express"
-version = "2021.7"
+version = "2021.7.2"
 homepage="https://sdk.purplship.com"
 repository="https://github.com/Purplship/purplship"
 description = "Purplship - DHL Express Shipping Extension"

--- a/purplship/README.md
+++ b/purplship/README.md
@@ -166,7 +166,7 @@ print(rates)
 ## Contributing
 
 We encourage you to contribute to puprlship! Please check out the
-[Contributing to purplship guide](/docs/development/contributing.md) for guidelines about how to proceed.
+[Contributing to purplship guide](/docs/contributing.md) for guidelines about how to proceed.
 [Join the purplship discord channel!](https://discord.gg/gS88uE7sEx)
 
 Do you want to extend purplship and integrate a custom carrier, check out 


### PR DESCRIPTION
- Add `MeasurementOptions` to ensure DHL measurements never get rounded to 0